### PR TITLE
Fix syntax error

### DIFF
--- a/src/icc.py
+++ b/src/icc.py
@@ -126,7 +126,7 @@ def parse_icc(content):
         nonlocal ptr
         if len(content) - ptr < n:
             raise Exception('Premature end of file: %s' % pathname)
-        rc = = content[ptr : ptr + n]
+        rc = content[ptr : ptr + n]
         ptr += n
         return rc
     


### PR DESCRIPTION
Fixes the following traceback I recieved when running blueshift immediately after installing:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/bin/blueshift/__main__.py", line 94, in <module>
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 954, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 896, in _find_spec
  File "<frozen importlib._bootstrap_external>", line 1139, in find_spec
  File "<frozen importlib._bootstrap_external>", line 1115, in _get_spec
  File "<frozen importlib._bootstrap_external>", line 1096, in _legacy_get_spec
  File "<frozen importlib._bootstrap>", line 444, in spec_from_loader
  File "<frozen importlib._bootstrap_external>", line 533, in spec_from_file_location
  File "/usr/bin/blueshift/icc.py", line 129
    rc = = content[ptr : ptr + n]
         ^
SyntaxError: invalid syntax
```